### PR TITLE
Update Docker docs and ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=strongpassword
+MYSQL_DATABASE=xiaozhi
+MYSQL_USER=xiaozhi_user
+MYSQL_PASSWORD=userpass

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ tmp
 .history
 .DS_Store
 main/xiaozhi-server/data
+!main/xiaozhi-server/data/.gitkeep
 main/xiaozhi-server/config/assets/wakeup_words.*
 main/manager-web/node_modules
 .config.yaml

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@
 | **最简化安装** | 智能对话、IOT功能，数据存储在配置文件 | 低配置环境，无需数据库 | [Docker只运行Server](./docs/Deployment.md#%E6%96%B9%E5%BC%8F%E4%B8%80docker%E5%8F%AA%E8%BF%90%E8%A1%8Cserver) | [本地源码只运行Server](./docs/Deployment.md#%E6%96%B9%E5%BC%8F%E4%BA%8C%E6%9C%AC%E5%9C%B0%E6%BA%90%E7%A0%81%E5%8F%AA%E8%BF%90%E8%A1%8Cserver)|
 | **全模块安装** | 智能对话、IOT、OTA、智控台，数据存储在数据库 | 完整功能体验 |[Docker运行全模块](./docs/Deployment_all.md#%E6%96%B9%E5%BC%8F%E4%B8%80docker%E8%BF%90%E8%A1%8C%E5%85%A8%E6%A8%A1%E5%9D%97) | [本地源码运行全模块](./docs/Deployment_all.md#%E6%96%B9%E5%BC%8F%E4%BA%8C%E6%9C%AC%E5%9C%B0%E6%BA%90%E7%A0%81%E8%BF%90%E8%A1%8C%E5%85%A8%E6%A8%A1%E5%9D%97) |
 
+如需使用统一的 `docker-compose.yml` 一键部署，可参考 [Docker 部署指南](./docs/DEPLOYMENT_DOCKER.md)。
+
 > 💡 提示：以下是按最新代码部署后的测试平台，有需要可烧录测试，并发为6个，每天会清空数据
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,94 @@
+version: '3.8'
+
+services:
+  mysql_db:
+    image: mysql:8.0
+    container_name: xiaozhi_mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-strongpassword}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-xiaozhi}
+      MYSQL_USER: ${MYSQL_USER:-xiaozhi_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-userpass}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - xiaozhi_network
+
+  redis_cache:
+    image: redis:6.2-alpine
+    container_name: xiaozhi_redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - xiaozhi_network
+
+  xiaozhi-device-service:
+    build:
+      context: ./main/xiaozhi-server
+      dockerfile: Dockerfile-server
+    container_name: xiaozhi_device_service
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+      - "8002:8002"
+    environment:
+      REDIS_HOST: redis_cache
+      REDIS_PORT: 6379
+      MANAGER_API_URL: http://xiaozhi-manager-api:8080
+    volumes:
+      - ./main/xiaozhi-server/config.yaml:/opt/xiaozhi-esp32-server/config.yaml
+      - ./main/xiaozhi-server/data:/opt/xiaozhi-esp32-server/data
+    depends_on:
+      - mysql_db
+      - redis_cache
+    networks:
+      - xiaozhi_network
+
+  xiaozhi-manager-api:
+    build:
+      context: ./main/manager-api
+      dockerfile: Dockerfile
+    container_name: xiaozhi_manager_api
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql_db:3306/${MYSQL_DATABASE:-xiaozhi}?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Shanghai
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER:-xiaozhi_user}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD:-userpass}
+      SPRING_REDIS_HOST: redis_cache
+      SPRING_REDIS_PORT: 6379
+      SPRING_PROFILES_ACTIVE: prod
+    depends_on:
+      - mysql_db
+      - redis_cache
+    networks:
+      - xiaozhi_network
+
+  xiaozhi-manager-web:
+    build:
+      context: ./main/manager-web
+      dockerfile: Dockerfile
+    container_name: xiaozhi_manager_web
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    depends_on:
+      - xiaozhi-manager-api
+    networks:
+      - xiaozhi_network
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  xiaozhi_network:
+    driver: bridge
+

--- a/docs/DEPLOYMENT_DOCKER.md
+++ b/docs/DEPLOYMENT_DOCKER.md
@@ -1,0 +1,59 @@
+# Docker 部署指南
+
+本指南介绍如何使用 `docker-compose.yml` 一键启动整套服务，包括 Python 设备服务、Java 后端、Vue 前端、MySQL 与 Redis。
+
+## 前置条件
+- 安装 [Docker](https://docs.docker.com/get-docker/) 与 [Docker Compose](https://docs.docker.com/compose/install/)。
+- 获取本仓库源码：
+
+```bash
+git clone <repo-url>
+cd xiaozhi-esp32-server
+```
+
+## 配置环境变量
+在项目根目录下创建 `.env` 文件，可直接复制 `.env.example`：
+
+```bash
+cp .env.example .env
+```
+
+`.env.example` 中包含了默认的数据库账号密码等参数，可根据实际需求修改。
+
+示例内容如下：
+
+```env
+MYSQL_ROOT_PASSWORD=strongpassword
+MYSQL_DATABASE=xiaozhi
+MYSQL_USER=xiaozhi_user
+MYSQL_PASSWORD=userpass
+```
+
+可根据实际需求调整数据库密码等参数。
+
+## 自定义配置
+复制 `main/xiaozhi-server/config.yaml` 到 `main/xiaozhi-server/data/.config.yaml` 后，可根据需要修改其中内容。该 `data` 目录会被挂载到容器的 `/opt/xiaozhi-esp32-server/data`，升级镜像时依旧保留你的个性化配置。
+
+## 构建并启动服务
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+首次运行会构建各镜像并启动下列服务：
+- `mysql_db`：数据库，端口 `3306`。
+- `redis_cache`：缓存服务，端口 `6379`。
+- `xiaozhi-device-service`：Python 服务，端口 `8000` 与 `8002`。
+- `xiaozhi-manager-api`：Java 后端，端口 `8080`。
+- `xiaozhi-manager-web`：前端服务，端口 `80`。
+
+浏览器访问 `http://localhost` 即可看到管理界面。
+
+## 常用命令
+- 查看运行状态：`docker compose ps`
+- 查看日志：`docker compose logs -f xiaozhi-manager-api`
+- 停止服务：`docker compose down`
+
+MySQL 与 Redis 数据分别持久化在 `mysql_data` 与 `redis_data` 卷中，可在 `docker-compose.yml` 中修改挂载路径。
+

--- a/main/README.md
+++ b/main/README.md
@@ -6,9 +6,11 @@
 ```
 xiaozhi-esp32-server
   ├─ xiaozhi-server 8000 端口 Python语言开发 负责与esp32通信
-  ├─ manager-web 8001 端口 Node.js+Vue开发 负责提供控制台的web界面
-  ├─ manager-api 8002 端口 Java语言开发 负责提供控制台的api
+  ├─ manager-web 80 端口（Docker 默认） Node.js+Vue开发 负责提供控制台的web界面
+  ├─ manager-api 8080 端口（Docker 默认） Java语言开发 负责提供控制台的api
 ```
+
+> 这些端口号基于 `docker-compose.yml` 的配置，若在本地独立运行各服务，可自行修改端口。
 
 # xiaozhi-server 和ESP32通讯协议
 

--- a/main/manager-api/Dockerfile
+++ b/main/manager-api/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM maven:3.9.4-eclipse-temurin-21 AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /app/target/xiaozhi-esp32-api.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]
+

--- a/main/manager-web/Dockerfile
+++ b/main/manager-web/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM node:18 AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM nginx:stable-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/main/xiaozhi-server/data/.gitkeep
+++ b/main/xiaozhi-server/data/.gitkeep
@@ -1,0 +1,1 @@
+# data files for persistent config


### PR DESCRIPTION
## Summary
- update port descriptions in `main/README.md`
- add persistent `data` volume for Python service in `docker-compose.yml`
- create `.env.example` and reference it in Docker guide
- document custom config placement and improved env setup
- track `main/xiaozhi-server/data/.gitkeep`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*
- `python -m pytest` *(fails: No module named pytest)*
- `node -v`